### PR TITLE
Adding credentials for recording tests to Cypress Dashboard

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -15,6 +15,6 @@
     }
   },
   "chromeWebSecurity": false,
-  "video": false
- 
+  "video": false,
+  "projectId": "2kbdmd"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Accessbility testing for Webfiling using Cypress.io",
   "main": "index.js",
   "scripts": {
-    "cypress:test": "cypress run --browser chrome",
+    "cypress:test": "cypress run --browser chrome --record --key 937e531b-f026-4271-ae21-5b2d5603ed60",
     "cypress:open": "cypress open",
     "precypress:open": "npm i & npm run lint",
     "precypress:test": "npm run precypress:open",


### PR DESCRIPTION
I've included the details for recording the test runs to Cypress Dashboard.
Currently this is using my credentials to record the details.
I am not sure what our plan will be when it comes to moving this from my GitHub to our organisation GitHub.
The dashboard appears to be free for 3 users. Will we need more?
https://www.cypress.io/pricing/

The Dashboard is public and can be viewed here:
https://dashboard.cypress.io/projects/2kbdmd/runs