### PR TITLE
Update to the latest version of Cypress. This change allows us to run…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -462,9 +462,9 @@
       }
     },
     "cypress": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.8.0.tgz",
-      "integrity": "sha512-gtEbqCgKETRc3pQFMsELRgIBNgiQg7vbOWTrCi7WE7bgOwNCaW9PEX8Jb3UN8z/maIp9WwzoFfeySfelYY7nRA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.8.1.tgz",
+      "integrity": "sha512-eLk5OpL/ZMDfQx9t7ZaDUAGVcvSOPTi7CG1tiUnu9BGk7caBiDhuFi3Tz/D5vWqH/Dl6Uh4X+Au4W+zh0xzbXw==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -2433,9 +2433,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
-      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
       "dev": true
     },
     "pump": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Accessbility testing for Webfiling using Cypress.io",
   "main": "index.js",
   "scripts": {
-    "cypress:test": "cypress run --browser chrome",
+    "cypress:test": "cypress run --browser chrome --headless",
     "cypress:open": "cypress open",
     "precypress:open": "npm i & npm run lint",
     "precypress:test": "npm run precypress:open",
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/rsuller/cypress_accessibility_webfiling#readme",
   "devDependencies": {
     "axe-core": "^3.4.0",
-    "cypress": "^3.8.0",
+    "cypress": "^3.8.1",
     "cypress-axe": "^0.5.1",
     "cypress-file-upload": "^3.5.1",
     "eslint": "^6.7.1",


### PR DESCRIPTION
… tests in chrome in `headless` mode. Which I have added to npm script.